### PR TITLE
Bump up werkzeug version to avoid TypError

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Flask==1.0.2
 Flask-Session==0.3.1
 Jinja2==2.10.1
 requests==2.21.0
-Werkzeug==0.15.3
-Werkzeug==0.15.3
+Werkzeug==0.15.5
+Werkzeug==0.15.5
 Flask-SocketIO>=4.2.1
 python-socketio>=4.3.0


### PR DESCRIPTION
https://stackoverflow.com/questions/60140174/basic-flask-app-not-running-typeerror-required-field-type-ignores-missing-fr